### PR TITLE
Add href to photo links

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -34,7 +34,8 @@ export default class extends React.Component {
     this.props.url.back()
   }
 
-  showPhoto (id) {
+  showPhoto (e, id) {
+    e.preventDefault()
     this.props.url.push('/photo?id=' + id)
   }
 
@@ -51,7 +52,10 @@ export default class extends React.Component {
         {
           this.props.photos.map((id) => (
             <div key={id} className={style(styles.photo)}>
-              <a className={style(styles.photoLink)} onClick={() => this.showPhoto(id) }>
+              <a
+                className={style(styles.photoLink)}
+                href={'/photo?id=' + id}
+                onClick={(e) => this.showPhoto(e, id) }>
                 {id}
               </a>
             </div>


### PR DESCRIPTION
I've added the `href` attribute to the photo links and canceled the default behaviour in the click handler.
This helps:
- opening a photo link in a new tab/window
- crawling the site for search engines that don't execute JS
- browsing the site without JS (unlikely but you never know...)
- with accessibility as well maybe?
